### PR TITLE
Fix: rename the require component to try get the sttusline component

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ or copy the template to your component module
 
 ```lua
 -- Change NewComponent to your component name
-local NewComponent = require("sttusline.set_component").new()
+local NewComponent = require("sttusline.component").new()
 
 -- The component will be update when the event is triggered
 -- To disable default event, set NewComponent.set_event = {}

--- a/lua/sttusline/utils/new-component.lua
+++ b/lua/sttusline/utils/new-component.lua
@@ -3,7 +3,7 @@ local fn = vim.fn
 
 local NEW_COMPONENT_TEMPLATE = [[
 -- Change NewComponent to your component name
-local NewComponent = require("sttusline.set_component").new()
+local NewComponent = require("sttusline.component").new()
 
 -- The component will be update when the event is triggered
 -- To disable default event, set NewComponent.set_event = {}


### PR DESCRIPTION
Hi, UwU
I was having an error when creating a component for the status line with the `SttuslineNewComponent`  command, it was reported that:
`module 'sttusline.set_component' not found: ...` 
Then the problem was fixed when in the created component was renamed the required class from `require("sttusline.set_component").new()` to `require("sttusline.component").new()`