### PR TITLE
Fix: Fixed deprecation

### DIFF
--- a/lua/sttusline/components/lsps-formatters.lua
+++ b/lua/sttusline/components/lsps-formatters.lua
@@ -5,7 +5,8 @@ return {
 	event = { "LspAttach", "LspDetach", "BufWritePost", "BufEnter", "VimResized" }, -- The component will be update when the event is triggered
 	colors = { fg = colors.magenta }, -- { fg = colors.black, bg = colors.white }
 	update = function()
-		local buf_clients = vim.lsp.get_clients()
+		local bufnr = vim.api.nvim_get_current_buf()
+		local buf_clients = vim.lsp.get_clients { bufnr = bufnr }
 		local server_names = {}
 		local has_null_ls = false
 		local ignore_lsp_servers = {
@@ -23,7 +24,7 @@ return {
 			has_null_ls, null_ls = pcall(require, "null-ls")
 
 			if has_null_ls then
-				local buf_ft = vim.api.nvim_buf_get_option(0, "filetype")
+				local buf_ft = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
 				local null_ls_methods = {
 					null_ls.methods.DIAGNOSTICS,
 					null_ls.methods.DIAGNOSTICS_ON_OPEN,

--- a/lua/sttusline/components/lsps-formatters.lua
+++ b/lua/sttusline/components/lsps-formatters.lua
@@ -5,7 +5,7 @@ return {
 	event = { "LspAttach", "LspDetach", "BufWritePost", "BufEnter", "VimResized" }, -- The component will be update when the event is triggered
 	colors = { fg = colors.magenta }, -- { fg = colors.black, bg = colors.white }
 	update = function()
-		local buf_clients = vim.lsp.buf_get_clients()
+		local buf_clients = vim.lsp.get_clients()
 		local server_names = {}
 		local has_null_ls = false
 		local ignore_lsp_servers = {


### PR DESCRIPTION
vim.lsp.buf_get_clients() will be deprecated in version 12, it is reccomended to use vim.lsp.get_clients() instead